### PR TITLE
将AsyncDrop从AbortSafeFuture中拆分出来

### DIFF
--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -1,0 +1,21 @@
+use abort_safe_future::AbortSafeFutureExt;
+use abort_safe_future::combinator::Compat;
+use abort_safe_future::executor::block_on;
+
+struct TestDrop;
+
+impl Drop for TestDrop {
+    fn drop(&mut self) {
+        println!("`TestDrop` is dropping")
+    }
+}
+
+fn main() {
+    block_on(Compat::new(async {
+        let _guard = TestDrop;
+        async {}.await;
+        println!("Hello, world!");
+    }).then(|_| Compat::new(async {
+        println!("Goodbye, world!");
+    })));
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,76 +1,53 @@
-use core::task::Context;
-use core::task::Poll;
-use core::pin::Pin;
-use core::mem::ManuallyDrop;
+use std::task::Context;
+use std::task::Poll;
+use std::pin::Pin;
+use std::mem::ManuallyDrop;
 
-use std::any::type_name;
-use std::task::ready;
 use crate::combinator::Then;
 use crate::helpers::pin_manually_drop_as_mut;
 
 
 /// abort safe future
-pub trait AbortSafeFuture {
+///
+// FIXME: 是否需要AbortSafeFuture: AsyncDrop这个约束?
+pub trait AbortSafeFuture: AsyncDrop {
     /// Future的结果类型
     type Output;
     /// 与std中的Future类似。
     /// 但需要注意：
     ///
     /// * 调用者无法析构`Self`，需要实现者自己实现资源的回收。
-    /// * 中断子future时，需要调用其`poll_cancel`方法，直到其返回`Poll::Ready`。否则可能内存泄漏。
+    /// * 完成或中断子future时，需要调用其`poll_drop`方法，直到其返回`Poll::Ready`。否则可能内存泄漏。
     fn poll(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<Self::Output>;
-
-    /// 当被取消时，调用此方法。
-    /// 返回值为`Poll::Ready`时，表示取消成功，此时应该完成了一些资源的回收工作
-    fn poll_cancel(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()>;
 }
 
+pub trait AsyncDrop {
+
+    /// 当Future成功或者需要中断之后调用，进行一些资源回收的工作。
+    ///
+    // FIXME: 是否下面这个签名更合适？
+    // ```rust
+    // unsafe fn poll_drop(self: *mut self, cx: &mut Context<'_>) -> Poll<()>;
+    // ```
+    fn poll_drop(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()>;
+}
+
+// FIXME: 这个实现是否合理? 违背了`poll`完需要`poll_drop`的约定
 impl<F: AbortSafeFuture + Unpin + ?Sized> AbortSafeFuture for &mut ManuallyDrop<F> {
     type Output = F::Output;
 
     fn poll(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         F::poll(Pin::new(&mut*self), cx)
     }
+}
 
-    fn poll_cancel(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()> {
-        F::poll_cancel(Pin::new(&mut*self), cx)
+impl<F: AsyncDrop + Unpin + ?Sized> AsyncDrop for &mut ManuallyDrop<F> {
+    fn poll_drop(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()> {
+        F::poll_drop(Pin::new(&mut*self), cx)
     }
 }
 
-impl<F: AbortSafeFuture + Unpin + ?Sized> AbortSafeFuture for Option<Box<ManuallyDrop<F>>> {
-    type Output = F::Output;
-
-    fn poll(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this: &mut Option<_> = &mut*self;
-        if let Some(fut) = this {
-            let output = ready!(F::poll(Pin::new(fut), cx));
-            // drop box is safe
-            unsafe {
-                ManuallyDrop::drop(fut);
-            }
-            *this = None;
-
-            Poll::Ready(output)
-        } else {
-            panic!("`{} poll after completion or after cancelled`", type_name::<Self>())
-        }
-    }
-
-    fn poll_cancel(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()> {
-        let this: &mut Option<_> = &mut*self;
-        if let Some(fut) = this {
-            ready!(F::poll_cancel(Pin::new(fut), cx));
-            // drop box is safe
-            unsafe {
-                ManuallyDrop::drop(fut);
-            }
-            *this = None;
-        }
-
-        Poll::Ready(())
-    }
-}
-
+// FIXME: 这个实现是否合理? 违背了`poll`完需要`poll_drop`的约定
 impl<F: AbortSafeFuture + ?Sized> AbortSafeFuture for Pin<&mut ManuallyDrop<F>> {
     type Output = F::Output;
 
@@ -78,48 +55,14 @@ impl<F: AbortSafeFuture + ?Sized> AbortSafeFuture for Pin<&mut ManuallyDrop<F>> 
         let inner = pin_manually_drop_as_mut(&mut self).as_deref_mut();
         F::poll(inner, cx)
     }
+}
 
-    fn poll_cancel(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()> {
+impl<F: AsyncDrop + ?Sized> AsyncDrop for Pin<&mut ManuallyDrop<F>> {
+    fn poll_drop(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()> {
         let inner = pin_manually_drop_as_mut(&mut self).as_deref_mut();
-        F::poll_cancel(inner, cx)
+        F::poll_drop(inner, cx)
     }
 }
-
-impl<F: AbortSafeFuture + ?Sized> AbortSafeFuture for Option<Pin<Box<ManuallyDrop<F>>>> {
-    type Output = F::Output;
-
-    fn poll(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut inner = pin_manually_drop_as_mut(&mut self);
-        if let Some(fut) = inner.as_mut().as_pin_mut().as_deref_mut() {
-            let output = ready!(F::poll(fut.as_mut(), cx));
-            // drop box is safe
-            unsafe {
-                ManuallyDrop::drop(fut.as_mut().get_unchecked_mut());
-            }
-            inner.set(None);
-
-            Poll::Ready(output)
-        } else {
-            panic!("`{} poll after completion or after cancelled`", type_name::<Self>())
-        }
-
-    }
-
-    fn poll_cancel(mut self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()> {
-        let mut inner = pin_manually_drop_as_mut(&mut self);
-        if let Some(fut) = inner.as_mut().as_pin_mut().as_deref_mut() {
-            ready!(F::poll_cancel(fut.as_mut(), cx));
-            // drop box is safe
-            unsafe {
-                ManuallyDrop::drop(fut.as_mut().get_unchecked_mut());
-            }
-            inner.set(None);
-        }
-
-        Poll::Ready(())
-    }
-}
-
 
 pub trait AbortSafeFutureExt: AbortSafeFuture {
     fn then<Fut, F>(self, f: F) -> Then<Self, Fut, F>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,66 +1,7 @@
-//!# AbortSafeFuture
-//!
-//! std中的Future可以通过随时来取消/中断。比如`select!`/`timeout`，会在一定条件下直接中断inner Future。
-//! 对于inner Future来说，就像是在.await处发生了panic，然后unwind the stack。
-//! 但这种中断Future本身是无法感知到的，不能像同步上下文那样子`catch_unwind`。
-//! 这不是一个好的设计。
-//!
-//! 所以这个新的api目标之一，是*让用户可以感知并处理Future的中断*。
-//!
-//!
-//! Future中断的原理是析构，而`poll`的参数是`Pin<&mut Self>`，我们随时可以中断掉一个Future，无论一个Future处在什么状态。
-//! 并且，`poll`是safe的，这就要求任意的Future，在任意状态都能被安全的析构。
-//! 这个条件其实是很强的，其实有很多异步的操作，都不满足这个条件。
-//!
-//! 比如下面的scoped task，假如`foo`产生的Future被中断了，字符串`s`就会被析构掉。但spawn的task不会被中断，这时候就会产生UB。
-//!
-//! ```no_run
-//! async fn foo() {
-//!     let s = String::from("hello");
-//!
-//!     task::scoped(|scp| async {
-//!         scp.spawn(async {
-//!             sleep(Duration::from_secs(10)).await;
-//!             println!("{}", s);
-//!         });
-//!     }).await;
-//! }
-//! ```
-//!
-//! 除了scoped task，其实也有不少异步的库因为要满足“随时可安全析构”的条件而难以设计（而且大概率有bug）。
-//!
-//! 所以这个新的api目标之二，是*让Future不可以随时被析构*。
-//!
-//! ## API
-//!
-//! ```no_run
-//! pub trait AbortSafeFuture {
-//!     type Output;
-//!     fn poll(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<Self::Output>;
-//!     fn poll_cancel(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()>;
-//! }
-//! ```
-//!
-//! 为了满足目标一，相比于std的Future，我们多提供了一个`poll_cancel`的方法，在需要中断的时候调用。如果不调用，就可能产生内存泄露（而非UB）。
-//! （有点类似于`AsyncDrop`要做的事情）。
-//!
-//! 而为了满足目标二，`poll_*`的参数是`self: Pin<&mut ManuallyDrop<Self>>`。
-//! 这样我们除了不能随意移动`Self`，也不能随意析构`Self`。
-//!
-//! 因为`Self`被`ManuallyDrop`和`Pin`保护了，所以`Self`自身的析构函数不会被调用.
-//! 所以所有资源回收的操作都需要在`poll_*`中完成，并由开发者自己保证正确性。
-//! 比如说，这个我们没办法为任意`Pin<Box<ManuallyDrop<Fut: AbortSafeFuture>>>`实现`AbortSafeFuture`，
-//! 因为`ManuallyDrop<Fut: AbortSafeFuture>`的析构函数是unsafe的。
-//!
-//! 这个api与其他类似的[api](https://docs.rs/completion-core/0.2.0/completion_core/trait.CompletionFuture.html)相比，
-//! 它不是unsafe的。因为所有的约束都可以通过语言提供的原语来满足。
-//!
-
 #![feature(arbitrary_self_types)]
 #![feature(pin_deref_mut)]
 #![feature(ready_macro)]
-
-extern crate core;
+#![doc = include_str!("../README.md")]
 
 pub mod future;
 pub mod combinator;


### PR DESCRIPTION
之前`AbortSafeFuture`中，`poll`和`poll_cancel`里面都需要有内存释放的逻辑。
可以单独抽离一个`AsyncDrop` trait来统一内存释放的逻辑。
而中断Future的逻辑也有`AsyncDrop`承担。

```rust
pub trait AbortSafeFuture: AsyncDrop {
    type Output;
    fn poll(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<Self::Output>;
}

pub trait AsyncDrop {
    fn poll_drop(self: Pin<&mut ManuallyDrop<Self>>, cx: &mut Context<'_>) -> Poll<()>;
}
```